### PR TITLE
added small setup.py file

### DIFF
--- a/mongodb_server/setup.py
+++ b/mongodb_server/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    name='pypersist',
+    install_requires=['Eve']
+)


### PR DESCRIPTION
Added a small setup.py file so that a user can type 'pip3 install .' to install mongo db server dependencies (which is just Eve for the time being). 